### PR TITLE
fix news image aspect ratio

### DIFF
--- a/solarboat-app/src/app/news-preview/news-preview.component.css
+++ b/solarboat-app/src/app/news-preview/news-preview.component.css
@@ -42,6 +42,8 @@
     max-width: 100%;
     max-height: 25em;
     display: block;
+    aspect-ratio: 3/2;
+    object-fit: cover;
 }
 .text-wrap{
     width:30rem;


### PR DESCRIPTION
automatically adjust the aspect ratio of all images in the news preview section to 3:2, by cropping them. This make pretty consistent boxes, yay!